### PR TITLE
Windowsで起動するとConfigがロードされないバグを修正

### DIFF
--- a/src/main/java/com/github/ucchyocean/bjm/Utility.java
+++ b/src/main/java/com/github/ucchyocean/bjm/Utility.java
@@ -59,7 +59,7 @@ public class Utility {
 
             } else {
                 reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
-                writer = new BufferedWriter(new OutputStreamWriter(fos));
+                writer = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
 
                 String line;
                 while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
お疲れ様です。プルリク失礼します。
Windowsでサーバーを起動した際、Shift-JIS形式で config.yml ファイルが生成されてしまい config が読み込まれないバグを修正しました。